### PR TITLE
Working, hello-world-c

### DIFF
--- a/challenges/hello-world-c/c11/CMakeLists.txt
+++ b/challenges/hello-world-c/c11/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.16)
+project(c11 C)
+
+set(CMAKE_C_STANDARD 11)
+
+add_executable(c11 main.c)

--- a/challenges/hello-world-c/c11/main.c
+++ b/challenges/hello-world-c/c11/main.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+#include <stdlib.h>
+
+int main() {
+    char s[100];
+    scanf("%[^\n]%*c", &s);
+
+    /* Enter your code here. Read input from STDIN. Print output to STDOUT */
+    puts("Hello, World!");
+    puts(s);
+    return 0;
+}


### PR DESCRIPTION
Points to study:
1. SCANF format string. '%' begins format specifier.
'[...]' begins a set. '^' within a set means complementary.
'\n' is a literal matching newline. So, '%[^\n]' matches
all characters except a newline. '%*c' matches one character
and then throws it away. '%' begins a new format specifier.
'*' instructs scanf to ignore the match. 'c' is any character.
2. Why the compiler says, "Format specifies type 'char *'
but the argument has type 'char (*)[100]"